### PR TITLE
Support to clojurescript >= 1.10.844

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,8 +6,8 @@
   :source-paths ["src"]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.7.122"]]
+  :dependencies [[org.clojure/clojure "1.11.4"]
+                 [org.clojure/clojurescript "1.11.132"]]
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
   :cljsbuild {:builds [{:id "network"

--- a/src/clojure/network/ip.cljc
+++ b/src/clojure/network/ip.cljc
@@ -8,7 +8,7 @@
         [java.net InetAddress Inet4Address Inet6Address]
         [java.lang UnsupportedOperationException])
     :cljs
-     (:require [goog.net.IpAddress :as ip]
+     (:require [goog.net.ipaddress.IpAddress :as ip]
                [goog.math.Integer :as i])))
 
 (defprotocol IPConstructor
@@ -26,8 +26,8 @@
 #?(:cljs
     (defn- bits->ip [bits]
       (if (= 1 (count bits))
-        (goog.net.Ipv4Address. (goog.math.Integer. bits 0))
-        (goog.net.Ipv6Address. (goog.math.Integer. bits 0)))))
+        (goog.net.ipaddress.Ipv4Address. (goog.math.Integer. bits 0))
+        (goog.net.ipaddress.Ipv6Address. (goog.math.Integer. bits 0)))))
 
 (deftype IPAddress [value]
   IPInfo


### PR DESCRIPTION
In clojurescript 1.10.844, the closure library was upgraded into v20210302

https://github.com/clojure/clojurescript/blob/master/changes.md#110844

In closure library v20210202, the IP classes were renamed

https://github.com/google/closure-library/releases/tag/v20210202