### PR TITLE
Make new IP namespace work

### DIFF
--- a/src/clojure/network/ip.cljc
+++ b/src/clojure/network/ip.cljc
@@ -8,7 +8,7 @@
         [java.net InetAddress Inet4Address Inet6Address]
         [java.lang UnsupportedOperationException])
     :cljs
-     (:require [goog.net.ipaddress.IpAddress :as ip]
+     (:require [goog.net.ipaddress :as ip]
                [goog.math.Integer :as i])))
 
 (defprotocol IPConstructor
@@ -26,8 +26,8 @@
 #?(:cljs
     (defn- bits->ip [bits]
       (if (= 1 (count bits))
-        (goog.net.ipaddress.Ipv4Address. (goog.math.Integer. bits 0))
-        (goog.net.ipaddress.Ipv6Address. (goog.math.Integer. bits 0)))))
+        (ip/Ipv4Address. (goog.math.Integer. bits 0))
+        (ip/Ipv6Address. (goog.math.Integer. bits 0)))))
 
 (deftype IPAddress [value]
   IPInfo
@@ -68,7 +68,7 @@
     (extend-type string
       IPConstructor
       (make-ip-address [this]
-        (->IPAddress (.-bits_ (.toInteger (ip/fromString this)))))))
+        (->IPAddress (.-bits_ (.toInteger (ip/IpAddress.fromString this)))))))
 
 #?(:clj
     (extend-type (Class/forName "[B")


### PR DESCRIPTION
First, thank you for your quick response and the new release.

After trying to use the version `1.4.0`, I realized it wasn't working because the new closure library namespace don't allow the requires as it used to be.

my apologies for the bad release. Here is the fix for it. Now tested in a large project, trusting not only in the build, but also runtime. 

